### PR TITLE
Add robust audio tag reader with tests

### DIFF
--- a/songsearch/__init__.py
+++ b/songsearch/__init__.py
@@ -1,0 +1,5 @@
+"""SongSearch package."""
+
+from .tags import read_tags
+
+__all__ = ["read_tags"]

--- a/songsearch/tags.py
+++ b/songsearch/tags.py
@@ -1,0 +1,94 @@
+"""Utilities for reading audio metadata tags.
+
+This module provides :func:`read_tags` which extracts common
+metadata fields from audio files using the `mutagen` library.  The
+function is tolerant to missing tags and parsing errors and always
+returns a dictionary with the expected keys.
+"""
+
+from dataclasses import dataclass, asdict
+from typing import Optional, Dict, Any, Tuple
+
+from mutagen import File as MutagenFile
+
+from .logger import logger
+
+
+@dataclass
+class SongTags:
+    """Simple container for metadata fields."""
+
+    title: Optional[str] = None
+    artist: Optional[str] = None
+    album: Optional[str] = None
+    year: Optional[str] = None
+    month: Optional[str] = None
+    genre: Optional[str] = None
+
+
+def _first_value(audio: Dict[str, Any], key: str) -> Optional[str]:
+    """Return the first value for *key* in *audio* if present."""
+    if key in audio and audio[key]:
+        value = audio[key][0]
+        return str(value) if value is not None else None
+    return None
+
+
+def _parse_date(value: Any) -> Tuple[Optional[str], Optional[str]]:
+    """Extract year and month from *value*.
+
+    The value may be ``None``, a list, or a string in the forms
+    ``YYYY`` or ``YYYY-MM``.  Month values are zero padded when
+    possible.
+    """
+    if not value:
+        return None, None
+
+    date_str = str(value).replace("/", "-")
+    parts = date_str.split("-")
+    year = parts[0] or None
+    month = None
+    if len(parts) > 1 and parts[1]:
+        month = parts[1].zfill(2)
+    return year, month
+
+
+def read_tags(file_path: str) -> Dict[str, Optional[str]]:
+    """Read common audio tags from *file_path*.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the audio file.
+
+    Returns
+    -------
+    Dict[str, Optional[str]]
+        Dictionary with keys ``title``, ``artist``, ``album``, ``year``,
+        ``month`` and ``genre``.  Missing tags are represented as
+        ``None``.
+    """
+
+    tags = SongTags()
+
+    try:
+        audio = MutagenFile(file_path, easy=True)
+        if not audio:
+            return asdict(tags)
+
+        tags.title = _first_value(audio, "title")
+        tags.artist = _first_value(audio, "artist")
+        tags.album = _first_value(audio, "album")
+        tags.genre = _first_value(audio, "genre")
+
+        date_val = (
+            _first_value(audio, "date")
+            or _first_value(audio, "originaldate")
+            or _first_value(audio, "year")
+        )
+        tags.year, tags.month = _parse_date(date_val)
+
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(f"Unable to read tags from {file_path}: {exc}")
+
+    return asdict(tags)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,44 @@
+import types
+import os, sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from songsearch import tags as tags_module
+
+
+class DummyAudio(dict):
+    """A minimal mapping mimicking Mutagen's EasyID3 behavior."""
+    pass
+
+
+def test_read_tags_basic(monkeypatch):
+    dummy = DummyAudio(
+        {
+            "title": ["My Song"],
+            "artist": ["An Artist"],
+            "album": ["An Album"],
+            "genre": ["Rock"],
+            "date": ["1999-7"],
+        }
+    )
+
+    def fake_mutagen_file(path, easy=True):
+        return dummy
+
+    monkeypatch.setattr(tags_module, "MutagenFile", fake_mutagen_file)
+    result = tags_module.read_tags("dummy.mp3")
+    assert result["title"] == "My Song"
+    assert result["artist"] == "An Artist"
+    assert result["year"] == "1999"
+    assert result["month"] == "07"
+    assert result["genre"] == "Rock"
+
+
+def test_read_tags_no_audio(monkeypatch):
+    def fake_mutagen_file(path, easy=True):
+        return None
+
+    monkeypatch.setattr(tags_module, "MutagenFile", fake_mutagen_file)
+    result = tags_module.read_tags("missing.mp3")
+    assert all(v is None for v in result.values())


### PR DESCRIPTION
## Summary
- add `read_tags` utility for extracting audio metadata via mutagen
- expose `read_tags` in package init
- cover tag parsing logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6bb01e4c8832cb5ef173a4fcd3ae3