### PR TITLE
Add destination path builder utility

### DIFF
--- a/songsearch/organizer/__init__.py
+++ b/songsearch/organizer/__init__.py
@@ -1,0 +1,9 @@
+"""Utilities for organizing files.
+
+Currently exposes :func:`build_destination` which builds the output path
+for a song based on its metadata.
+"""
+
+from .destination import build_destination
+
+__all__ = ["build_destination"]

--- a/songsearch/organizer/destination.py
+++ b/songsearch/organizer/destination.py
@@ -1,0 +1,26 @@
+import os
+import re
+from typing import Dict
+
+from ..config import DEFAULT_DEST_TEMPLATE
+
+
+def _safe(s: str, max_len: int = 80) -> str:
+    s = (s or "Unknown").strip()
+    s = re.sub(r'[\\/:*?"<>|]+', "_", s)
+    return s[:max_len]
+
+
+def build_destination(
+    base_dir: str, meta: Dict[str, str], ext: str, template: str = DEFAULT_DEST_TEMPLATE
+) -> str:
+    values = {
+        "year": _safe(meta.get("year") or "Unknown"),
+        "month": _safe(meta.get("month") or "00"),
+        "genre": _safe(meta.get("genre") or "Unknown"),
+        "artist": _safe(meta.get("artist") or "Unknown"),
+        "title": _safe(meta.get("title") or "Unknown"),
+        "ext": ext.lower(),
+    }
+    rel = template.format(**values)
+    return os.path.normpath(os.path.join(base_dir, rel))

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from songsearch.organizer import build_destination
+
+
+def test_build_destination_basic(tmp_path):
+    meta = {
+        "year": "2023",
+        "month": "07",
+        "genre": "Rock",
+        "artist": "AC/DC",
+        "title": "Thunder / Storm",
+    }
+    dest = build_destination(str(tmp_path), meta, ".MP3")
+    expected = (
+        tmp_path
+        / "2023"
+        / "07"
+        / "Rock"
+        / "AC_DC"
+        / "AC_DC - Thunder _ Storm.mp3"
+    )
+    assert dest == str(expected)
+
+
+def test_build_destination_defaults(tmp_path):
+    dest = build_destination(str(tmp_path), {}, ".FLAC")
+    expected = (
+        tmp_path
+        / "Unknown"
+        / "00"
+        / "Unknown"
+        / "Unknown"
+        / "Unknown - Unknown.flac"
+    )
+    assert dest == str(expected)
+
+
+def test_safe_truncation_and_ext(tmp_path):
+    long = "x" * 100
+    meta = {"artist": long, "title": long}
+    dest = build_destination(str(tmp_path), meta, ".MP3")
+    truncated = "x" * 80
+    filename = os.path.basename(dest)
+    assert filename == f"{truncated} - {truncated}.mp3"
+    artist_dir = os.path.basename(os.path.dirname(dest))
+    assert artist_dir == truncated


### PR DESCRIPTION
## Summary
- add `build_destination` function to compute organized output paths from song metadata
- expose `build_destination` via `songsearch.organizer`
- add tests verifying path sanitization, defaults, and extension handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c36461dc832cbca58a365da24795