### PR TITLE
Add move planning and CSV export utilities

### DIFF
--- a/songsearch/organizer/__init__.py
+++ b/songsearch/organizer/__init__.py
@@ -5,5 +5,6 @@ for a song based on its metadata.
 """
 
 from .destination import build_destination
+from .plan import plan_moves, export_plan_csv
 
-__all__ = ["build_destination"]
+__all__ = ["build_destination", "plan_moves", "export_plan_csv"]

--- a/songsearch/organizer/plan.py
+++ b/songsearch/organizer/plan.py
@@ -1,0 +1,103 @@
+import os
+import csv
+from typing import List, Dict, Tuple
+
+from ..tags import read_tags
+from ..musicbrainz import enrich_with_musicbrainz
+from .destination import build_destination
+
+
+def plan_moves(file_paths: List[str], base_dest_dir: str) -> List[Dict[str, str]]:
+    """Create a move plan for *file_paths*.
+
+    Each file is inspected using :func:`read_tags` and enriched with
+    information from MusicBrainz via :func:`enrich_with_musicbrainz`.
+    The resulting metadata is fed into :func:`build_destination` to obtain
+    the proposed destination path.  Any exceptions are captured and
+    reported in the returned plan instead of bubbling up.
+
+    Parameters
+    ----------
+    file_paths:
+        List of source file paths to plan moves for.
+    base_dest_dir:
+        Base directory under which the destination paths are built.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        A list of dictionaries describing the move plan for each file.  On
+        success, entries contain ``status="ok"`` and the proposed path; on
+        failure, ``status="error"`` with a reason message.
+    """
+
+    plan: List[Dict[str, str]] = []
+    for src in file_paths:
+        try:
+            ext = os.path.splitext(src)[1]
+            local = read_tags(src)
+            mb = enrich_with_musicbrainz(src)
+            meta = {**local, **mb}
+            dest = build_destination(base_dest_dir, meta, ext)
+            plan.append(
+                {
+                    "original_path": src,
+                    "proposed_path": dest,
+                    "status": "ok",
+                    "reason": "planned",
+                    "title": meta.get("title") or "",
+                    "artist": meta.get("artist") or "",
+                    "album": meta.get("album") or "",
+                    "year": meta.get("year") or "",
+                    "month": meta.get("month") or "",
+                    "genre": meta.get("genre") or "",
+                }
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            plan.append(
+                {
+                    "original_path": src,
+                    "proposed_path": "",
+                    "status": "error",
+                    "reason": str(exc),
+                    "title": "",
+                    "artist": "",
+                    "album": "",
+                    "year": "",
+                    "month": "",
+                    "genre": "",
+                }
+            )
+    return plan
+
+
+def export_plan_csv(plan: List[Dict[str, str]], csv_path: str) -> Tuple[int, int]:
+    """Write *plan* to ``csv_path`` and return counts of successes/errors."""
+
+    ok = sum(1 for r in plan if r.get("status") == "ok")
+    errors = sum(1 for r in plan if r.get("status") != "ok")
+
+    fields = [
+        "original_path",
+        "proposed_path",
+        "status",
+        "reason",
+        "title",
+        "artist",
+        "album",
+        "year",
+        "month",
+        "genre",
+    ]
+
+    dir_name = os.path.dirname(csv_path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in plan:
+            writer.writerow(row)
+
+    return ok, errors

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,110 @@
+import csv
+
+import pytest
+
+from songsearch.organizer import plan_moves, export_plan_csv
+
+
+def test_plan_moves_success(monkeypatch):
+    def fake_read_tags(path):
+        assert path == "src/song.MP3"
+        return {"title": "Local", "genre": "LocalGenre"}
+
+    def fake_enrich(path):
+        assert path == "src/song.MP3"
+        return {"title": "MBTitle", "artist": "MBArtist", "year": "2021"}
+
+    def fake_build(base, meta, ext):
+        assert base == "/base"
+        assert ext == ".MP3"
+        assert meta["title"] == "MBTitle"
+        assert meta["artist"] == "MBArtist"
+        # local genre preserved
+        assert meta["genre"] == "LocalGenre"
+        return "/final/MBArtist - MBTitle.mp3"
+
+    monkeypatch.setattr("songsearch.organizer.plan.read_tags", fake_read_tags)
+    monkeypatch.setattr(
+        "songsearch.organizer.plan.enrich_with_musicbrainz", fake_enrich
+    )
+    monkeypatch.setattr("songsearch.organizer.plan.build_destination", fake_build)
+
+    plan = plan_moves(["src/song.MP3"], "/base")
+    assert plan == [
+        {
+            "original_path": "src/song.MP3",
+            "proposed_path": "/final/MBArtist - MBTitle.mp3",
+            "status": "ok",
+            "reason": "planned",
+            "title": "MBTitle",
+            "artist": "MBArtist",
+            "album": "",
+            "year": "2021",
+            "month": "",
+            "genre": "LocalGenre",
+        }
+    ]
+
+
+def test_plan_moves_error(monkeypatch):
+    def fake_read_tags(path):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("songsearch.organizer.plan.read_tags", fake_read_tags)
+
+    plan = plan_moves(["bad.mp3"], "/base")
+    assert plan == [
+        {
+            "original_path": "bad.mp3",
+            "proposed_path": "",
+            "status": "error",
+            "reason": "boom",
+            "title": "",
+            "artist": "",
+            "album": "",
+            "year": "",
+            "month": "",
+            "genre": "",
+        }
+    ]
+
+
+def test_export_plan_csv(tmp_path):
+    plan = [
+        {
+            "original_path": "a",
+            "proposed_path": "b",
+            "status": "ok",
+            "reason": "planned",
+            "title": "t",
+            "artist": "ar",
+            "album": "al",
+            "year": "1",
+            "month": "2",
+            "genre": "g",
+        },
+        {
+            "original_path": "c",
+            "proposed_path": "",
+            "status": "error",
+            "reason": "oops",
+            "title": "",
+            "artist": "",
+            "album": "",
+            "year": "",
+            "month": "",
+            "genre": "",
+        },
+    ]
+
+    csv_path = tmp_path / "sub" / "plan.csv"
+    ok, errors = export_plan_csv(plan, str(csv_path))
+    assert ok == 1
+    assert errors == 1
+    assert csv_path.exists()
+
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2
+    assert rows[0]["original_path"] == "a"
+    assert rows[1]["status"] == "error"


### PR DESCRIPTION
## Summary
- implement `plan_moves` to combine tag and MusicBrainz data and propose destination paths
- add `export_plan_csv` to write plan summaries
- expose new utilities from `songsearch.organizer` and add unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c42781ec832ca363da80df8dd650