### PR TITLE
Add basic main window and organizer panel stub

### DIFF
--- a/songsearch/main_window.py
+++ b/songsearch/main_window.py
@@ -1,0 +1,22 @@
+from PyQt5.QtWidgets import QMainWindow, QTabWidget
+
+from .ui.search_panel import SearchPanel
+from .ui.organizer_panel import OrganizerPanel
+from .config import APP_NAME
+
+
+class MainWindow(QMainWindow):
+    """Main application window.
+
+    The window hosts two tabs: one for searching the database and another for
+    organizing files.  Each tab is backed by its respective widget.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle(APP_NAME)
+        self.resize(1100, 700)
+        tabs = QTabWidget()
+        tabs.addTab(SearchPanel(self), "Buscar")
+        tabs.addTab(OrganizerPanel(self), "Organizar")
+        self.setCentralWidget(tabs)

--- a/songsearch/ui/__init__.py
+++ b/songsearch/ui/__init__.py
@@ -1,6 +1,6 @@
 """UI components for SongSearch."""
 
 from .search_panel import SearchPanel
+from .organizer_panel import OrganizerPanel
 
-__all__ = ["SearchPanel"]
-
+__all__ = ["SearchPanel", "OrganizerPanel"]

--- a/songsearch/ui/organizer_panel.py
+++ b/songsearch/ui/organizer_panel.py
@@ -1,0 +1,17 @@
+"""Placeholder organizer panel widget.
+
+This simple widget will eventually allow users to organize their music
+collection.  For now it only displays a message indicating that the feature is
+under development.
+"""
+
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class OrganizerPanel(QWidget):
+    """Minimal organizer panel used in the main window."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Organizador en desarrollo"))


### PR DESCRIPTION
## Summary
- add a MainWindow hosting search and organizer tabs
- create placeholder OrganizerPanel widget
- expose OrganizerPanel in UI package

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c63ed660832c83d158a7e586e3f5