### PR TITLE
Add tests for fuzzy fuzzy search modes and thresholds

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import pytest
+
+# Ensure the package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from songsearch.db import DatabaseManager
+from songsearch.search import fuzzy_search
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    db = DatabaseManager(str(tmp_path / "songs.db"))
+    songs = [
+        {
+            "name": "song1.mp3",
+            "artist": "The Beatles",
+            "title": "Hey Jude",
+            "path": "song1.mp3",
+        },
+        {
+            "name": "song2.mp3",
+            "artist": "The Rolling Stones",
+            "title": "Paint It Black",
+            "path": "song2.mp3",
+        },
+        {
+            "name": "song3.mp3",
+            "artist": "Queen",
+            "title": "Bohemian Rhapsody",
+            "path": "song3.mp3",
+        },
+    ]
+    for song in songs:
+        db.add_song(**song)
+    return db
+
+
+def test_fuzzy_search_artist(sample_db):
+    results = fuzzy_search(sample_db, "beatles", "artist", 80)
+    assert len(results) == 1
+    assert results[0]["artist"] == "The Beatles"
+
+    high_threshold = fuzzy_search(sample_db, "beatles", "artist", 85)
+    assert high_threshold == []
+
+
+def test_fuzzy_search_song(sample_db):
+    results = fuzzy_search(sample_db, "bohemian", "song", 70)
+    assert len(results) == 1
+    assert results[0]["title"] == "Bohemian Rhapsody"
+
+    high_threshold = fuzzy_search(sample_db, "bohemian", "song", 80)
+    assert high_threshold == []


### PR DESCRIPTION
## Summary
- add unit tests for fuzzy_search to check artist and song modes with varying thresholds

## Testing
- `pytest tests/test_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d0b85ca8832ca1ef147696ff6d82