### PR TITLE
Validate mode parameter in search_song_like

### DIFF
--- a/songsearch/db.py
+++ b/songsearch/db.py
@@ -63,9 +63,27 @@ class DatabaseManager:
             c.execute("UPDATE songs SET path=? WHERE name=?", (new_path, name,))
 
     def search_song_like(self, query: str, mode: str = "song") -> List[Tuple]:
+        """Search for songs by title or artist using a LIKE query.
+
+        Args:
+            query: Substring to match within the selected column.
+            mode: "song" to search by song title, "artist" to search by artist name.
+
+        Returns:
+            List of tuples representing matching rows.
+
+        Raises:
+            ValueError: If *mode* is not "song" or "artist".
+        """
+        if mode not in {"song", "artist"}:
+            raise ValueError("mode must be 'song' or 'artist'")
+
         col = "title" if mode == "song" else "artist"
         with self._conn() as c:
-            return c.execute(f"SELECT id,name,artist,path,title FROM songs WHERE {col} LIKE ?", (f"%{query}%",)).fetchall()
+            return c.execute(
+                f"SELECT id,name,artist,path,title FROM songs WHERE {col} LIKE ?",
+                (f"%{query}%",),
+            ).fetchall()
 
     def fetch_all_for_fuzzy(self) -> List[Tuple]:
         with self._conn() as c:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -53,3 +53,8 @@ def test_fuzzy_search_song(sample_db):
 
     high_threshold = fuzzy_search(sample_db, "bohemian", "song", 80)
     assert high_threshold == []
+
+
+def test_search_song_like_invalid_mode(sample_db):
+    with pytest.raises(ValueError):
+        sample_db.search_song_like("query", "album")


### PR DESCRIPTION
## Summary
- enforce mode validation in `DatabaseManager.search_song_like`
- add unit test for invalid mode usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d2a26434832c9765fbb65ea412a7