### PR TITLE
Fix fuzzy_search import path in search panel

### DIFF
--- a/songsearch/ui/search_panel.py
+++ b/songsearch/ui/search_panel.py
@@ -39,7 +39,7 @@ from PyQt5.QtWidgets import (
 from ..config import DEFAULT_FUZZY_THRESHOLD, FILE_EXTS
 from ..db import DatabaseManager
 from ..logger import logger
-from ..search.engine import fuzzy_search
+from ..search import fuzzy_search
 
 
 class SearchPanel(QWidget):


### PR DESCRIPTION
## Summary
- Update SearchPanel to import `fuzzy_search` from top-level search module

## Testing
- `pytest -q`
- `python - <<'PY'
import os
os.environ['QT_QPA_PLATFORM'] = 'offscreen'
from PyQt5.QtWidgets import QApplication
from songsearch.app import MainWindow
from PyQt5.QtCore import QTimer
app = QApplication([])
w = MainWindow()
QTimer.singleShot(0, app.quit)
w.show()
app.exec_()
print('App started and exited')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c6d4816608832cbacd3280f23de136