### PR TITLE
Log planning errors with stack trace

### DIFF
--- a/songsearch/organizer/plan.py
+++ b/songsearch/organizer/plan.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Tuple
 from ..tags import read_tags
 from ..musicbrainz import enrich_with_musicbrainz
 from .destination import build_destination
+from ..logger import logger
 
 
 def plan_moves(file_paths: List[str], base_dest_dir: str) -> List[Dict[str, str]]:
@@ -54,6 +55,7 @@ def plan_moves(file_paths: List[str], base_dest_dir: str) -> List[Dict[str, str]
                 }
             )
         except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Error planning move for %s", src)
             plan.append(
                 {
                     "original_path": src,


### PR DESCRIPTION
## Summary
- log stack traces when planning file moves fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d5304364832ca44c70d106c7c005