### PR TITLE
Log missing AcoustID API key in musicbrainz lookup

### DIFF
--- a/songsearch/musicbrainz.py
+++ b/songsearch/musicbrainz.py
@@ -63,6 +63,10 @@ def enrich_with_musicbrainz(file_path: str) -> Dict[str, Any]:
         return tags
 
     api_key = os.environ.get("ACOUSTID_API_KEY")
+    if api_key is None:
+        logger.info(
+            "ACOUSTID_API_KEY not set; performing lookup without API key which may impose limitations"
+        )
 
     try:
         lookup = pyacoustid.lookup(api_key, fingerprint, duration)


### PR DESCRIPTION
## Summary
- Log that AcoustID API key is missing and lookup will proceed without it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d62359ac832ca46c41e1e2a1aaf3