### PR TITLE
Optimize fuzzy search candidate selection

### DIFF
--- a/songsearch/db.py
+++ b/songsearch/db.py
@@ -85,6 +85,25 @@ class DatabaseManager:
                 (f"%{query}%",),
             ).fetchall()
 
-    def fetch_all_for_fuzzy(self) -> List[Tuple]:
+    def fetch_all_for_fuzzy(self, query: str, mode: str) -> List[Tuple]:
+        """Fetch candidate rows for fuzzy search using a LIKE filter.
+
+        Args:
+            query: Text used to pre-filter rows.
+            mode: "artist" to search against artist names, otherwise search song
+                titles and filenames.
+        """
         with self._conn() as c:
-            return c.execute("SELECT id,name,artist,title,path FROM songs").fetchall()
+            if mode == "artist":
+                return c.execute(
+                    "SELECT id,name,artist,title,path FROM songs WHERE artist LIKE ?",
+                    (f"%{query}%",),
+                ).fetchall()
+            # song mode: filter by title or name
+            return c.execute(
+                """
+                SELECT id,name,artist,title,path FROM songs
+                WHERE title LIKE ? OR name LIKE ?
+                """,
+                (f"%{query}%", f"%{query}%"),
+            ).fetchall()

--- a/songsearch/search/__init__.py
+++ b/songsearch/search/__init__.py
@@ -13,7 +13,7 @@ def fuzzy_search(db: DatabaseManager, query: str, mode: str, threshold: int) -> 
         mode: "artist" to match against artist names, otherwise match song titles/names.
         threshold: Minimum score (0-100) required for a match.
     """
-    rows = db.fetch_all_for_fuzzy()
+    rows = db.fetch_all_for_fuzzy(query, mode)
 
     if mode == "artist":
         choices = [(r[2] or "", r) for r in rows]  # artist, row

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -58,3 +58,23 @@ def test_fuzzy_search_song(sample_db):
 def test_search_song_like_invalid_mode(sample_db):
     with pytest.raises(ValueError):
         sample_db.search_song_like("query", "album")
+
+
+def test_fetch_all_for_fuzzy_filters_results(sample_db):
+    all_rows = sample_db.fetch_all_for_fuzzy("", "song")
+    assert len(all_rows) == 3
+
+    filtered = sample_db.fetch_all_for_fuzzy("bo", "song")
+    assert len(filtered) == 1
+    assert filtered[0][3] == "Bohemian Rhapsody"
+
+    artist_filtered = sample_db.fetch_all_for_fuzzy("beat", "artist")
+    assert len(artist_filtered) == 1
+    assert artist_filtered[0][2] == "The Beatles"
+
+
+def test_fuzzy_search_reduces_candidates(sample_db):
+    # threshold 0 ensures results would include all songs if not filtered
+    results = fuzzy_search(sample_db, "bo", "song", 0)
+    assert len(results) == 1
+    assert results[0]["title"] == "Bohemian Rhapsody"


### PR DESCRIPTION
## Summary
- Filter database results in `fetch_all_for_fuzzy` using LIKE queries based on search mode
- Pass query and mode from `fuzzy_search` into the database lookup
- Test candidate reduction and precise filtering for fuzzy searches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d69ca0a4832c86005deb5c578c33