### PR TITLE
feat(threads): indexado y dry-run en segundo plano con QThread, progreso y cancelación

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# src package

--- a/src/threads/__init__.py
+++ b/src/threads/__init__.py
@@ -1,0 +1,1 @@
+# threads package

--- a/src/threads/workers.py
+++ b/src/threads/workers.py
@@ -1,0 +1,111 @@
+from typing import List, Set
+import os
+from datetime import datetime
+from PyQt5.QtCore import QObject, pyqtSignal
+
+# Importes locales (se importan aquí para evitar problemas de import cruzado en UI)
+from ..db import DatabaseManager
+from ..organizer.dryrun import plan_moves
+
+class IndexWorker(QObject):
+    """Escanea una carpeta y añade entradas a la DB en segundo plano."""
+    progress = pyqtSignal(int, int)          # current, total
+    message = pyqtSignal(str)                # log/status
+    finished = pyqtSignal(int)               # count indexed
+    error = pyqtSignal(str)
+
+    def __init__(self, root_dir: str, allowed_exts: Set[str]):
+        super().__init__()
+        self.root_dir = root_dir
+        self.allowed_exts = allowed_exts
+        self._stop = False
+
+    def stop(self):
+        self._stop = True
+
+    def run(self):
+        try:
+            db = DatabaseManager()
+            # 1) pre-contar archivos para progreso
+            files = []
+            for r, _, fs in os.walk(self.root_dir):
+                for f in fs:
+                    ext = os.path.splitext(f)[1].lower()
+                    if ext in self.allowed_exts:
+                        files.append(os.path.join(r, f))
+            total = len(files)
+            count = 0
+            self.message.emit(f"Encontrados {total} archivos candidatos.")
+
+            # 2) indexar
+            for i, p in enumerate(files, start=1):
+                if self._stop:
+                    self.message.emit("Indexado cancelado por el usuario.")
+                    break
+                try:
+                    name, ext = os.path.splitext(os.path.basename(p))
+                    size = os.path.getsize(p)
+                    mdate = datetime.fromtimestamp(os.path.getmtime(p)).strftime("%Y-%m-%d %H:%M:%S")
+                    db.add_song(name=name, artist=None, title=None, album=None, year=None, month=None, genre=None,
+                                path=p, duration=None, file_format=ext.lower(), size=size, modified_date=mdate,
+                                original_path=p)
+                    count += 1
+                except Exception as e:
+                    self.message.emit(f"Error indexando: {p} -> {e}")
+                # Progreso
+                self.progress.emit(i, total)
+            self.finished.emit(count)
+        except Exception as e:
+            self.error.emit(str(e))
+
+
+class DryRunWorker(QObject):
+    """Genera un plan de Dry-Run (organizer) en segundo plano."""
+    progress = pyqtSignal(int, int)          # current, total
+    message = pyqtSignal(str)
+    finished = pyqtSignal(list)              # plan list
+    error = pyqtSignal(str)
+
+    def __init__(self, src_dir: str, dest_dir: str, file_exts: Set[str]):
+        super().__init__()
+        self.src_dir = src_dir
+        self.dest_dir = dest_dir
+        self.file_exts = file_exts
+        self._stop = False
+
+    def stop(self):
+        self._stop = True
+
+    def run(self):
+        try:
+            # 1) recolectar archivos
+            files: List[str] = []
+            for root, _, fs in os.walk(self.src_dir):
+                for f in fs:
+                    ext = os.path.splitext(f)[1].lower()
+                    if ext in self.file_exts:
+                        files.append(os.path.join(root, f))
+            total = len(files)
+            self.message.emit(f"Dry-Run: {total} archivos a procesar.")
+
+            # 2) dividir en bloques y planificar (para progresos periódicos)
+            if total == 0:
+                self.finished.emit([])
+                return
+
+            # plan_moves ya procesa una lista; para progreso,
+            # haremos chunks manuales.
+            chunk = max(1, total // 20)  # ~20 pasos de progreso
+            plan = []
+            for i in range(0, total, chunk):
+                if self._stop:
+                    self.message.emit("Dry-Run cancelado por el usuario.")
+                    break
+                sub = files[i:i+chunk]
+                subplan = plan_moves(sub, self.dest_dir)
+                plan.extend(subplan)
+                self.progress.emit(min(i+len(sub), total), total)
+
+            self.finished.emit(plan)
+        except Exception as e:
+            self.error.emit(str(e))

--- a/src/ui/organizer_panel.py
+++ b/src/ui/organizer_panel.py
@@ -1,0 +1,148 @@
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+                             QFileDialog, QTableWidget, QTableWidgetItem, QHeaderView, QLineEdit, QProgressBar)
+from PyQt5.QtCore import QThread
+from typing import List
+import os
+
+from ..organizer.dryrun import export_plan_csv
+from ..organizer.mb_client import detect_fpcalc
+from ..config import FILE_EXTS
+from ..threads.workers import DryRunWorker
+
+class OrganizerPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.src_dir = None
+        self.dest_dir = None
+        self.plan = []
+        self.thread: QThread = None
+        self.worker: DryRunWorker = None
+
+        layout = QVBoxLayout(self)
+
+        ctrl = QHBoxLayout()
+        self.src_btn = QPushButton("Elegir carpeta ORIGEN")
+        self.dest_btn = QPushButton("Elegir carpeta DESTINO Base")
+        self.run_btn = QPushButton("Previsualizar (Dry-Run en hilo)")
+        self.cancel_btn = QPushButton("Cancelar Dry-Run"); self.cancel_btn.setEnabled(False)
+        self.export_btn = QPushButton("Exportar CSV"); self.export_btn.setEnabled(False)
+        ctrl.addWidget(self.src_btn); ctrl.addWidget(self.dest_btn)
+        ctrl.addWidget(self.run_btn); ctrl.addWidget(self.cancel_btn); ctrl.addWidget(self.export_btn)
+        layout.addLayout(ctrl)
+
+        self.fpcalc_note = QLabel("")
+        if detect_fpcalc():
+            self.fpcalc_note.setText("✔ Huellas acústicas disponibles (fpcalc detectado).")
+        else:
+            self.fpcalc_note.setText("ℹ Instala 'fpcalc' (Chromaprint) para identificación avanzada.")
+        layout.addWidget(self.fpcalc_note)
+
+        self.dest_label = QLineEdit(); self.dest_label.setPlaceholderText("p.ej. D:/MusicOrganized")
+        layout.addWidget(self.dest_label)
+
+        # Progreso
+        prog = QHBoxLayout()
+        self.progress = QProgressBar(); self.progress.setRange(0, 100); self.progress.setValue(0)
+        self.status = QLabel("Listo.")
+        prog.addWidget(QLabel("Dry-Run:")); prog.addWidget(self.progress); prog.addWidget(self.status)
+        layout.addLayout(prog)
+
+        # Tabla
+        self.table = QTableWidget(0, 5)
+        self.table.setHorizontalHeaderLabels(["Estado","Motivo","Origen","Propuesto","Meta (Artista - Título)"])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        layout.addWidget(self.table)
+
+        # Conexiones
+        self.src_btn.clicked.connect(self.select_src)
+        self.dest_btn.clicked.connect(self.select_dest)
+        self.run_btn.clicked.connect(self.run_dryrun_threaded)
+        self.cancel_btn.clicked.connect(self.cancel_dryrun)
+        self.export_btn.clicked.connect(self.export_csv)
+
+    def select_src(self):
+        d = QFileDialog.getExistingDirectory(self, "Seleccionar carpeta ORIGEN")
+        if d: self.src_dir = d
+
+    def select_dest(self):
+        d = QFileDialog.getExistingDirectory(self, "Seleccionar carpeta DESTINO Base")
+        if d:
+            self.dest_dir = d
+            self.dest_label.setText(d)
+
+    # ---------- DRY-RUN EN HILO ----------
+    def run_dryrun_threaded(self):
+        self.dest_dir = self.dest_label.text().strip() or self.dest_dir
+        if not self.src_dir or not self.dest_dir: 
+            self.status.setText("Falta origen o destino.")
+            return
+
+        self.thread = QThread()
+        self.worker = DryRunWorker(self.src_dir, self.dest_dir, FILE_EXTS)
+        self.worker.moveToThread(self.thread)
+
+        self.thread.started.connect(self.worker.run)
+        self.worker.progress.connect(self._on_progress)
+        self.worker.message.connect(self._on_message)
+        self.worker.finished.connect(self._on_finished)
+        self.worker.error.connect(self._on_error)
+
+        self.worker.finished.connect(lambda _: self.thread.quit())
+        self.worker.finished.connect(lambda _: self.worker.deleteLater())
+        self.thread.finished.connect(lambda: self.thread.deleteLater())
+
+        self._toggle_ui(running=True)
+        self.status.setText("Calculando plan...")
+        self.progress.setValue(0)
+        self.table.setRowCount(0)
+
+        self.thread.start()
+
+    def _on_progress(self, current: int, total: int):
+        pct = int((current / total) * 100) if total else 0
+        self.progress.setValue(pct)
+
+    def _on_message(self, msg: str):
+        self.status.setText(msg)
+
+    def _on_finished(self, plan: list):
+        self.plan = plan
+        self._render_table(plan)
+        self.status.setText("Dry-Run completado.")
+        self.progress.setValue(100)
+        self.export_btn.setEnabled(bool(plan))
+        self._toggle_ui(running=False)
+
+    def _on_error(self, err: str):
+        self.status.setText(f"Error: {err}")
+        self._toggle_ui(running=False)
+
+    def cancel_dryrun(self):
+        if self.worker:
+            self.worker.stop()
+            self.status.setText("Cancelando...")
+
+    def _toggle_ui(self, running: bool):
+        self.run_btn.setEnabled(!running if False else (not running))
+        self.cancel_btn.setEnabled(running)
+        self.src_btn.setEnabled(not running)
+        self.dest_btn.setEnabled(not running)
+        self.export_btn.setEnabled(not running and bool(self.plan))
+
+    def _render_table(self, plan):
+        self.table.setRowCount(0)
+        for row in plan:
+            r = self.table.rowCount()
+            self.table.insertRow(r)
+            self.table.setItem(r, 0, QTableWidgetItem(row["status"]))
+            self.table.setItem(r, 1, QTableWidgetItem(row["reason"]))
+            self.table.setItem(r, 2, QTableWidgetItem(row["original_path"]))
+            self.table.setItem(r, 3, QTableWidgetItem(row["proposed_path"]))
+            meta = f'{row.get("artist","")}' + " - " + f'{row.get("title","")}'
+            meta = meta.strip(" -")
+            self.table.setItem(r, 4, QTableWidgetItem(meta))
+
+    def export_csv(self):
+        if not self.plan: return
+        path, _ = QFileDialog.getSaveFileName(self, "Guardar CSV", "dryrun_mapping.csv", "CSV (*.csv)")
+        if path: export_plan_csv(self.plan, path)

--- a/src/ui/search_panel.py
+++ b/src/ui/search_panel.py
@@ -1,0 +1,239 @@
+import os
+from datetime import datetime
+from typing import Set
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel, QTextEdit, QPushButton,
+                             QSlider, QRadioButton, QButtonGroup, QListWidget, QFileDialog, QCheckBox,
+                             QListWidgetItem, QTextEdit as QLog, QProgressBar)
+from PyQt5.QtCore import Qt, QUrl, QThread
+from PyQt5.QtGui import QColor
+from PyQt5.QtMultimedia import QMediaPlayer, QMediaContent
+
+from ..db import DatabaseManager
+from ..config import FILE_EXTS, DEFAULT_FUZZY_THRESHOLD
+from ..search.engine import fuzzy_search
+from ..logger import logger
+from ..threads.workers import IndexWorker
+
+class SearchPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.db = DatabaseManager()
+        self.selected_folder = None
+        self.player = QMediaPlayer()
+        self.index_thread: QThread = None
+        self.index_worker: IndexWorker = None
+        self._build_ui()
+        self.player.positionChanged.connect(self._update_position)
+        self.player.durationChanged.connect(self._update_duration)
+
+    def _build_ui(self):
+        main = QVBoxLayout(self)
+
+        top = QHBoxLayout()
+        self.input_text = QTextEdit(); top.addWidget(self.input_text)
+
+        btns = QVBoxLayout()
+        self.search_button = QPushButton("Buscar")
+        self.folder_button = QPushButton("Elegir Carpeta")
+        self.update_button = QPushButton("Actualizar Base de Datos (hilo)")
+        self.clear_button = QPushButton("Limpiar")
+        self.cancel_index_button = QPushButton("Cancelar Indexado")
+        self.cancel_index_button.setEnabled(False)
+
+        btns.addWidget(self.search_button)
+        btns.addWidget(self.folder_button)
+        btns.addWidget(self.update_button)
+        btns.addWidget(self.cancel_index_button)
+        btns.addWidget(self.clear_button)
+        top.addLayout(btns)
+
+        self.results = QListWidget(); top.addWidget(self.results)
+        main.addLayout(top)
+
+        # Controles de Reproducción
+        controls = QHBoxLayout()
+        self.play_pause_button = QPushButton("Play"); self.play_pause_button.setEnabled(False)
+        self.progress_bar = QSlider(Qt.Horizontal); self.progress_bar.setRange(0, 100); self.progress_bar.setEnabled(False)
+        controls.addWidget(self.play_pause_button); controls.addWidget(self.progress_bar)
+        main.addLayout(controls)
+
+        # Parámetros
+        params = QGridLayout()
+        params.addWidget(QLabel("Parámetros de Búsqueda:"), 0, 0, 1, 2)
+
+        self.artist_radio = QRadioButton("Artista")
+        self.song_radio = QRadioButton("Canción")
+        self.song_radio.setChecked(True)
+        group = QButtonGroup(); group.addButton(self.artist_radio); group.addButton(self.song_radio)
+        params.addWidget(self.artist_radio, 1, 0); params.addWidget(self.song_radio, 1, 1)
+
+        self.quality_slider = QSlider(Qt.Horizontal); self.quality_slider.setRange(0, 100); self.quality_slider.setValue(DEFAULT_FUZZY_THRESHOLD)
+        self.intensity_label = QLabel(f"Intensidad de Búsqueda: {DEFAULT_FUZZY_THRESHOLD}%")
+        self.quality_slider.valueChanged.connect(lambda v: self.intensity_label.setText(f"Intensidad de Búsqueda: {v}%"))
+        params.addWidget(self.intensity_label, 2, 0); params.addWidget(self.quality_slider, 2, 1)
+
+        params.addWidget(QLabel("Formatos de Archivo:"), 3, 0, 1, 2)
+        ft = QGridLayout(); self.file_type_checkboxes = {}
+        exts = sorted(list(FILE_EXTS)); r=c=0
+        for e in exts:
+            cb = QCheckBox(e.upper()); cb.setChecked(True); self.file_type_checkboxes[e]=cb
+            ft.addWidget(cb, r, c); c+=1
+            if c>3: c=0; r+=1
+        params.addLayout(ft, 4, 0, 1, 2)
+        main.addLayout(params)
+
+        # Progreso + Log
+        prog_row = QHBoxLayout()
+        self.index_progress = QProgressBar(); self.index_progress.setRange(0, 100); self.index_progress.setValue(0)
+        self.index_status = QLabel("Listo.")
+        prog_row.addWidget(QLabel("Indexado:")); prog_row.addWidget(self.index_progress); prog_row.addWidget(self.index_status)
+        main.addLayout(prog_row)
+
+        self.log = QLog(); self.log.setReadOnly(True); self.log.setFixedHeight(90)
+        main.addWidget(self.log)
+
+        # conexiones
+        self.folder_button.clicked.connect(self._select_folder)
+        self.search_button.clicked.connect(self._perform_search)
+        self.update_button.clicked.connect(self._update_database_threaded)
+        self.cancel_index_button.clicked.connect(self._cancel_index)
+        self.clear_button.clicked.connect(self._clear)
+        self.results.itemDoubleClicked.connect(self._handle_double_click)
+        self.play_pause_button.clicked.connect(self._toggle_play_pause)
+        self.progress_bar.sliderMoved.connect(self.player.setPosition)
+
+    def _allowed_exts(self) -> Set[str]:
+        return {ext for ext, cb in self.file_type_checkboxes.items() if cb.isChecked()}
+
+    # ---------- INDEXADO EN HILO ----------
+    def _update_database_threaded(self):
+        if not self.selected_folder:
+            self._select_folder()
+            if not self.selected_folder:
+                self.log.append("No se seleccionó ninguna carpeta.")
+                return
+        # Preparar hilo + worker
+        self.index_thread = QThread()
+        self.index_worker = IndexWorker(self.selected_folder, self._allowed_exts())
+        self.index_worker.moveToThread(self.index_thread)
+
+        # Señales
+        self.index_thread.started.connect(self.index_worker.run)
+        self.index_worker.progress.connect(self._on_index_progress)
+        self.index_worker.message.connect(self._on_index_message)
+        self.index_worker.finished.connect(self._on_index_finished)
+        self.index_worker.error.connect(self._on_index_error)
+
+        # limpiar al finalizar
+        self.index_worker.finished.connect(lambda _: self.index_thread.quit())
+        self.index_worker.finished.connect(lambda _: self.index_worker.deleteLater())
+        self.index_thread.finished.connect(lambda: self.index_thread.deleteLater())
+
+        # UI estado
+        self._toggle_index_ui(running=True)
+        self.index_status.setText("Indexando...")
+
+        self.index_thread.start()
+
+    def _on_index_progress(self, current: int, total: int):
+        pct = int((current / total) * 100) if total else 0
+        self.index_progress.setValue(pct)
+
+    def _on_index_message(self, msg: str):
+        self.log.append(msg)
+
+    def _on_index_finished(self, count: int):
+        self.log.append(f"Indexado completado: {count} archivos añadidos.")
+        self.index_status.setText("Completado.")
+        self._toggle_index_ui(running=False)
+
+    def _on_index_error(self, err: str):
+        self.log.append(f"Error en indexado: {err}")
+        self.index_status.setText("Error.")
+        self._toggle_index_ui(running=False)
+
+    def _cancel_index(self):
+        if self.index_worker:
+            self.index_worker.stop()
+            self.log.append("Cancelando indexado...")
+
+    def _toggle_index_ui(self, running: bool):
+        self.update_button.setEnabled(not running)
+        self.cancel_index_button.setEnabled(running)
+        self.folder_button.setEnabled(not running)
+        self.search_button.setEnabled(not running)
+        self.clear_button.setEnabled(not running)
+
+    # ---------- RESTO UI ----------
+    def _select_folder(self):
+        d = QFileDialog.getExistingDirectory(self, "Seleccionar Carpeta")
+        if d:
+            self.selected_folder = d
+            self.log.append(f"Carpeta seleccionada: {d}")
+
+    def _clear(self):
+        self.input_text.clear(); self.results.clear(); self.log.clear()
+
+    def _perform_search(self):
+        rows = [s.strip() for s in self.input_text.toPlainText().strip().splitlines() if s.strip()]
+        if not rows:
+            self.log.append("Introduce canciones o artistas.")
+            return
+        mode = "artist" if self.artist_radio.isChecked() else "song"
+        thr = self.quality_slider.value()
+        self.results.clear()
+        found_any = False
+        for q in rows:
+            matches = fuzzy_search(self.db, q.lower(), mode, thr)
+            if matches:
+                for m in matches:
+                    self._add_result(m["title"] or m["name"] or q, "found", m["path"])
+                found_any = True
+            else:
+                self._add_result(q, "not_found")
+        self.log.append("Búsqueda completada (coincidencias encontradas)." if found_any else "Sin coincidencias.")
+
+    def _add_result(self, name, status, path=None):
+        item = QListWidgetItem(name)
+        if status == "found":
+            item.setForeground(QColor("green"))
+            item.setToolTip(path or "")
+        else:
+            item.setForeground(QColor("red"))
+            item.setToolTip("No encontrado.")
+        self.results.addItem(item)
+
+    def _handle_double_click(self, item):
+        color = item.foreground().color().name()
+        if color == "#008000":  # verde
+            self._play(item.toolTip())
+        elif color == "#ff0000":  # rojo
+            self._assign_location(item)
+
+    def _assign_location(self, item):
+        file_path, _ = QFileDialog.getOpenFileName(self, "Asignar archivo", self.selected_folder or "")
+        if file_path:
+            item.setForeground(QColor("green"))
+            item.setToolTip(file_path)
+            self.log.append(f"Ubicación asignada a '{item.text()}'.")
+            self.db.update_song_location(item.text(), file_path)
+
+    def _play(self, path):
+        if not path or not os.path.exists(path):
+            self.log.append("Archivo no disponible.")
+            return
+        self.player.setMedia(QMediaContent(QUrl.fromLocalFile(os.path.normpath(path))))
+        self.player.play(); self.play_pause_button.setEnabled(True)
+        self.log.append(f"Reproduciendo: {path}")
+
+    def _toggle_play_pause(self):
+        if self.player.state() == QMediaPlayer.PlayingState:
+            self.player.pause(); self.play_pause_button.setText("Play")
+        else:
+            self.player.play(); self.play_pause_button.setText("Pause")
+
+    def _update_position(self, pos=None):
+        self.progress_bar.setValue(self.player.position())
+
+    def _update_duration(self, duration):
+        self.progress_bar.setRange(0, duration); self.progress_bar.setEnabled(True)


### PR DESCRIPTION
## Summary
- Add threaded workers for DB indexing and organizer dry-run operations
- Update SearchPanel to index in background with progress/cancel controls
- Update OrganizerPanel to run dry-run planning in a worker thread

## Testing
- `pytest`
- `python -m src.main` *(fails: No module named src.main)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d767b1d8832c9c8e7631c5ee02b5