### PR TITLE
Handle missing PyQt5 gracefully

### DIFF
--- a/songsearch/__main__.py
+++ b/songsearch/__main__.py
@@ -1,13 +1,48 @@
+"""Entry point for the :mod:`songsearch` package."""
+
+from __future__ import annotations
+
 import sys
-from PyQt5.QtWidgets import QApplication
-from .app import MainWindow
+from typing import Optional
+
+try:  # pragma: no cover - import side effects are environment dependent
+    from PyQt5.QtWidgets import QApplication  # type: ignore
+    _IMPORT_ERROR: Optional[Exception] = None
+except Exception as exc:  # noqa: BLE001 - we want to catch anything import might raise
+    QApplication = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
 
 
-def main():
-    app = QApplication(sys.argv)
-    w = MainWindow()
-    w.show()
-    sys.exit(app.exec_())
+def main() -> None:
+    """Launch the application.
+
+    If PyQt5 (or its native dependencies such as ``libGL``) is not available,
+    a friendly message is printed instead of raising an ``ImportError`` at
+    import time.  This makes the module usable in headless environments and
+    provides clearer feedback to the user.
+    """
+
+    if QApplication is None:  # pragma: no cover - only triggered when Qt missing
+        print(
+            "PyQt5 is required to run the GUI but could not be imported:\n"
+            f"{_IMPORT_ERROR}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        app = QApplication(sys.argv)
+        from .app import MainWindow
+        w = MainWindow()
+        w.show()
+        sys.exit(app.exec_())
+    except Exception as exc:  # pragma: no cover - environment dependent
+        print(
+            "Failed to start the GUI:\n"
+            f"{exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,27 @@
+import pytest
+from songsearch import __main__ as main_module
+
+
+def test_main_missing_pyqt_exits_with_message(monkeypatch, capsys):
+    """main() should exit gracefully when PyQt is unavailable."""
+    monkeypatch.setattr(main_module, 'QApplication', None)
+    main_module._IMPORT_ERROR = RuntimeError('boom')
+    with pytest.raises(SystemExit) as excinfo:
+        main_module.main()
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert 'PyQt5 is required to run the GUI' in captured.err
+
+
+def test_main_qt_start_failure(monkeypatch, capsys):
+    """main() should handle errors during Qt startup."""
+    def fake_qapp(argv):  # pylint: disable=unused-argument
+        raise RuntimeError('no display')
+
+    monkeypatch.setattr(main_module, 'QApplication', fake_qapp)
+    main_module._IMPORT_ERROR = None
+    with pytest.raises(SystemExit) as excinfo:
+        main_module.main()
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert 'Failed to start the GUI' in captured.err


### PR DESCRIPTION
## Summary
- avoid ImportError when PyQt5 or libGL are unavailable
- provide friendly message when GUI cannot launch
- add regression tests ensuring CLI exits cleanly on Qt import or startup failures

## Testing
- `pytest -q`
- `python -m songsearch`


------
https://chatgpt.com/codex/tasks/task_e_68c6dda67c1c832ca5a29630a870ce37