### PR TITLE
Fix run button state toggle in organizer panel

### DIFF
--- a/src/ui/organizer_panel.py
+++ b/src/ui/organizer_panel.py
@@ -123,7 +123,7 @@ class OrganizerPanel(QWidget):
             self.status.setText("Cancelando...")
 
     def _toggle_ui(self, running: bool):
-        self.run_btn.setEnabled(!running if False else (not running))
+        self.run_btn.setEnabled(not running)
         self.cancel_btn.setEnabled(running)
         self.src_btn.setEnabled(not running)
         self.dest_btn.setEnabled(not running)


### PR DESCRIPTION
## Summary
- Simplify run button enabled check using `not running`
- Keeps other UI toggles unchanged

## Testing
- `python -m py_compile src/ui/organizer_panel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e10a8994832c8564c11d4d4434a9