### PR TITLE
Remove unused read_tags import from mb_client

### DIFF
--- a/src/organizer/mb_client.py
+++ b/src/organizer/mb_client.py
@@ -1,6 +1,6 @@
 import os
 from typing import Dict, Any, Optional, Tuple, List
-from .scanner import read_tags  # por si queremos fusionar tags locales como fallback
+
 from ..config import MB_APP_NAME, MB_APP_VERSION, MB_CONTACT, ACOUSTID_API_KEY
 from ..logger import logger
 


### PR DESCRIPTION
## Summary
- remove stale read_tags import from organizer's MusicBrainz client

## Testing
- `python -m py_compile src/organizer/mb_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e299a684832cbc78ef4a255d3b49