### PR TITLE
Initialize data directory at runtime

### DIFF
--- a/songsearch/__main__.py
+++ b/songsearch/__main__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from typing import Optional
 
+from . import config
+
 try:  # pragma: no cover - import side effects are environment dependent
     from PyQt5.QtWidgets import QApplication  # type: ignore
     _IMPORT_ERROR: Optional[Exception] = None
@@ -21,6 +23,7 @@ def main() -> None:
     import time.  This makes the module usable in headless environments and
     provides clearer feedback to the user.
     """
+    config.init_paths()
 
     if QApplication is None:  # pragma: no cover - only triggered when Qt missing
         print(

--- a/songsearch/config.py
+++ b/songsearch/config.py
@@ -3,7 +3,6 @@ import os
 APP_NAME = "SongSearch"
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, "..", "data")
-os.makedirs(DATA_DIR, exist_ok=True)
 DB_PATH = os.path.join(DATA_DIR, "songsearch.db")
 
 # Extensiones soportadas
@@ -26,4 +25,15 @@ MB_CONTACT = ""  # e.g. your email or project URL (optional courtesy)
 # AcoustID API key.  Can also be provided via the ``ACOUSTID_API_KEY``
 # environment variable; the configuration value is used as a fallback.
 ACOUSTID_API_KEY = os.environ.get("ACOUSTID_API_KEY", "")
+
+
+def init_paths() -> None:
+    """Create required application directories.
+
+    Ensures that :data:`DATA_DIR` exists before components such as the
+    database attempt to use it.  This avoids performing filesystem
+    operations at import time.
+    """
+
+    os.makedirs(DATA_DIR, exist_ok=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from songsearch import config
+
+
+@pytest.fixture(autouse=True)
+def init_data_dir() -> None:
+    """Ensure required paths are initialized for tests."""
+    config.init_paths()


### PR DESCRIPTION
## Summary
- move creation of data directory into a new `init_paths` helper
- invoke path initialization from `__main__` and test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6ebc7d888832ca949537b738ae749