### PR TITLE
Add tests for configuration module

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,7 @@
+from songsearch import config
+
+
+def test_config_has_app_name_and_mp3_extension():
+    assert hasattr(config, "APP_NAME")
+    assert ".mp3" in config.FILE_EXTS
+


### PR DESCRIPTION
## Summary
- add unit test for songsearch.config
- verify APP_NAME exists and ".mp3" is supported extension

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f4e58a50832c9469c8a2da664290