### PR TITLE
Add MusicBrainz enrichment test with genre support

### DIFF
--- a/songsearch/musicbrainz.py
+++ b/songsearch/musicbrainz.py
@@ -101,7 +101,7 @@ def enrich_with_musicbrainz(file_path: str) -> Dict[str, Any]:
             MB_CONTACT or None,
         )
         mb_data = musicbrainzngs.get_recording_by_id(
-            recording_id, includes=["artists", "releases"]
+            recording_id, includes=["artists", "releases", "genres"]
         )
     except Exception as exc:  # pragma: no cover - network failure
         logger.warning(
@@ -125,6 +125,12 @@ def enrich_with_musicbrainz(file_path: str) -> Dict[str, Any]:
         artist = artists[0]
         if isinstance(artist, dict):
             tags["artist"] = artist.get("artist", {}).get("name")
+
+    genres = recording.get("genres")
+    if genres:
+        genre = genres[0].get("name") if isinstance(genres[0], dict) else None
+        if genre:
+            tags["genre"] = genre
 
     releases = recording.get("releases")
     if releases:

--- a/tests/test_mb_client_mock.py
+++ b/tests/test_mb_client_mock.py
@@ -1,0 +1,54 @@
+"""Tests for enrich_with_musicbrainz with mocked external services."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import songsearch.musicbrainz as mb
+
+
+def test_enrich_with_musicbrainz_mock(monkeypatch):
+    dummy_fpcalc = "/usr/bin/fpcalc"
+
+    def fake_detect_fpcalc():
+        return dummy_fpcalc
+
+    monkeypatch.setattr(mb, "detect_fpcalc", fake_detect_fpcalc)
+
+    class FakeAcoustid:
+        @staticmethod
+        def fingerprint_file(file_path, fpcalc_path=None):
+            assert fpcalc_path == dummy_fpcalc
+            return 123, "abc"
+
+        @staticmethod
+        def lookup(api_key, fingerprint, duration):
+            return {"results": [{"recordings": [{"id": "rec123"}]}]}
+
+    monkeypatch.setattr(mb, "pyacoustid", FakeAcoustid)
+
+    class FakeMB:
+        @staticmethod
+        def set_useragent(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def get_recording_by_id(recording_id, includes=None):
+            return {
+                "recording": {
+                    "title": "Test Title",
+                    "artist-credit": [{"artist": {"name": "Test Artist"}}],
+                    "releases": [{"title": "Test Album", "date": "2015-03-01"}],
+                    "genres": [{"name": "Rock"}],
+                }
+            }
+
+    monkeypatch.setattr(mb, "musicbrainzngs", FakeMB)
+
+    result = mb.enrich_with_musicbrainz("dummy.mp3")
+    assert result["title"] == "Test Title"
+    assert result["artist"] == "Test Artist"
+    assert result["album"] == "Test Album"
+    assert result["year"] == "2015"
+    assert result["genre"] == "Rock"


### PR DESCRIPTION
## Summary
- Teach `enrich_with_musicbrainz` to request genre data and include the first genre in returned tags
- Add unit test mocking AcoustID/MusicBrainz clients to verify enrichment of title, artist, album, year, and genre

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f72f9d78832ca5a83f29763a60bf