### PR TITLE
Add UI smoke test using pytest-qt

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1,0 +1,14 @@
+import os
+
+# Ensure that tests run without a display server
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from songsearch.app import MainWindow
+
+
+def test_mainwindow_is_visible(qtbot):
+    """MainWindow should be instantiable and visible."""
+    window = MainWindow()
+    qtbot.addWidget(window)
+    window.show()
+    assert window.isVisible()


### PR DESCRIPTION
## Summary
- add a smoke test that instantiates and displays the MainWindow using pytest-qt with QT_QPA_PLATFORM=offscreen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa946db8832cbfd954087f714295