### PR TITLE
Add macOS LaunchAgent installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Run the application from the project root:
 python -m songsearch
 ```
 
+## macOS auto-start
+To have SongSearch2 launch automatically when you log in on macOS, run:
+
+```bash
+./scripts/install_macos_launch_agent.sh
+```
+
+This script creates a `LaunchAgent` that starts the app at login and keeps it running.
+
 ## Running Tests
 Execute the test suite with:
 

--- a/scripts/install_macos_launch_agent.sh
+++ b/scripts/install_macos_launch_agent.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Installs a LaunchAgent to start SongSearch2 automatically at login on macOS.
+
+set -e
+
+PLIST_NAME="com.songsearch2.launch.plist"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+DEST="$LAUNCH_AGENTS_DIR/$PLIST_NAME"
+
+mkdir -p "$LAUNCH_AGENTS_DIR"
+
+python_path="$(command -v python3)"
+repo_path="$(cd "$(dirname "$0")/.." && pwd)"
+
+cat > "$DEST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.songsearch2</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${python_path}</string>
+        <string>-m</string>
+        <string>songsearch</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>${repo_path}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/songsearch2.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/songsearch2.err</string>
+</dict>
+</plist>
+PLIST
+
+launchctl unload "$DEST" 2>/dev/null || true
+launchctl load "$DEST"
+
+echo "LaunchAgent installed to $DEST"


### PR DESCRIPTION
## Summary
- document how to auto-start SongSearch2 on macOS
- add script to install a macOS LaunchAgent for auto-start

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c70b24f7b8832caa7fa9e86806984d