### PR TITLE
Use gui-specific launchctl commands

### DIFF
--- a/scripts/install_macos_launch_agent.sh
+++ b/scripts/install_macos_launch_agent.sh
@@ -39,7 +39,7 @@ cat > "$DEST" <<PLIST
 </plist>
 PLIST
 
-launchctl unload "$DEST" 2>/dev/null || true
-launchctl load "$DEST"
+launchctl bootout "gui/$UID" "$DEST" 2>/dev/null || true
+launchctl bootstrap "gui/$UID" "$DEST"
 
 echo "LaunchAgent installed to $DEST"


### PR DESCRIPTION
## Summary
- use bootout/bootstrap with gui/$UID for macOS launch agents
- quote gui/$UID to keep domain argument intact

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run -m pytest -p pytestqt.plugin`
- `coverage report -m`
- `python scripts/smoke_app.py` *(fails: could not load the Qt platform plugin "xcb" in "" even though it was found)*

------
https://chatgpt.com/codex/tasks/task_e_68c70c2d0760832cb826ca510f63d79e