### PR TITLE
feat: add organizer panel

### DIFF
--- a/songsearch/app.py
+++ b/songsearch/app.py
@@ -1,16 +1,33 @@
-from PyQt5.QtWidgets import QMainWindow, QTabWidget
+from PyQt5.QtWidgets import QAction, QMainWindow, QTabWidget
 
 from .ui.search_panel import SearchPanel
 from .ui.organizer_panel import OrganizerPanel
 
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("SongSearch")
         self.resize(1100, 700)
-        tabs = QTabWidget()
-        tabs.addTab(SearchPanel(self), "Buscar")
-        tabs.addTab(OrganizerPanel(self), "Organizar")
-        self.setCentralWidget(tabs)
 
+        self.tabs = QTabWidget()
+        self.search_panel = SearchPanel(self)
+        self.organizer_panel = OrganizerPanel(self)
+        self.tabs.addTab(self.search_panel, "Buscar")
+        self.tabs.addTab(self.organizer_panel, "Organizar")
+        self.setCentralWidget(self.tabs)
+
+        self._build_menus()
+
+    def _build_menus(self) -> None:
+        menubar = self.menuBar()
+        org_menu = menubar.addMenu("Organizar")
+        act_select = QAction("Seleccionar archivos", self)
+        act_dest = QAction("Seleccionar destino", self)
+        act_run = QAction("Organizar ahora", self)
+        org_menu.addAction(act_select)
+        org_menu.addAction(act_dest)
+        org_menu.addAction(act_run)
+        act_select.triggered.connect(self.organizer_panel.select_files)
+        act_dest.triggered.connect(self.organizer_panel.select_destination)
+        act_run.triggered.connect(self.organizer_panel.organize_files)

--- a/songsearch/ui/organizer_panel.py
+++ b/songsearch/ui/organizer_panel.py
@@ -1,17 +1,105 @@
-"""Placeholder organizer panel widget.
+"""Panel de organización de archivos de música.
 
-This simple widget will eventually allow users to organize their music
-collection.  For now it only displays a message indicating that the feature is
-under development.
+Este panel permite al usuario seleccionar archivos y moverlos a una carpeta de
+ destino basada en los metadatos de cada canción.  Las rutas se calculan usando
+ las utilidades del módulo :mod:`songsearch.organizer`.
 """
 
-from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+from __future__ import annotations
+
+import os
+import shutil
+from typing import List
+
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..organizer.plan import plan_moves
 
 
 class OrganizerPanel(QWidget):
-    """Minimal organizer panel used in the main window."""
+    """Panel que permite organizar archivos en carpetas de destino."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Organizador en desarrollo"))
+        self.file_paths: List[str] = []
+        self.dest_dir: str = ""
+        self._build_ui()
+
+    # ------------------------------------------------------------------ UI --
+    def _build_ui(self) -> None:
+        main = QVBoxLayout(self)
+
+        file_btn = QPushButton("Seleccionar Archivos")
+        file_btn.clicked.connect(self.select_files)
+        main.addWidget(file_btn)
+
+        dest_layout = QHBoxLayout()
+        dest_layout.addWidget(QLabel("Destino:"))
+        self.dest_edit = QLineEdit()
+        self.dest_edit.setReadOnly(True)
+        dest_layout.addWidget(self.dest_edit)
+        dest_btn = QPushButton("Elegir Destino")
+        dest_btn.clicked.connect(self.select_destination)
+        dest_layout.addWidget(dest_btn)
+        main.addLayout(dest_layout)
+
+        self.files_list = QListWidget()
+        main.addWidget(self.files_list)
+
+        organize_btn = QPushButton("Organizar")
+        organize_btn.clicked.connect(self.organize_files)
+        main.addWidget(organize_btn)
+
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setFixedHeight(100)
+        main.addWidget(self.log)
+
+    # -------------------------------------------------------------- actions --
+    def select_files(self) -> None:
+        paths, _ = QFileDialog.getOpenFileNames(self, "Seleccionar archivos")
+        if paths:
+            self.file_paths = list(paths)
+            self.files_list.clear()
+            self.files_list.addItems(paths)
+            self.log.append(f"{len(paths)} archivos seleccionados.")
+
+    def select_destination(self) -> None:
+        d = QFileDialog.getExistingDirectory(self, "Seleccionar carpeta destino")
+        if d:
+            self.dest_dir = d
+            self.dest_edit.setText(d)
+            self.log.append(f"Carpeta destino: {d}")
+
+    def organize_files(self) -> None:
+        if not self.file_paths:
+            self.log.append("No se han seleccionado archivos.")
+            return
+        if not self.dest_dir:
+            self.log.append("Seleccione una carpeta de destino.")
+            return
+
+        plan = plan_moves(self.file_paths, self.dest_dir)
+        for item in plan:
+            src = item.get("original_path", "")
+            dest = item.get("proposed_path", "")
+            if item.get("status") == "ok" and src and dest:
+                try:
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    shutil.move(src, dest)
+                    self.log.append(f"Movido: {src} -> {dest}")
+                except Exception as exc:  # pragma: no cover - logging only
+                    self.log.append(f"Error al mover {src}: {exc}")
+            else:
+                reason = item.get("reason", "desconocido")
+                self.log.append(f"Error con {src}: {reason}")


### PR DESCRIPTION
## Summary
- replace placeholder organizer panel with file selection and destination-move logic
- wire main window menu actions to new organizer panel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c73fcb2840832c9c4c670a894da957