### PR TITLE
Add icons and stylesheet to SongSearch UI

### DIFF
--- a/songsearch/app.py
+++ b/songsearch/app.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from PyQt5.QtCore import QFile
 from PyQt5.QtWidgets import QAction, QMainWindow, QTabWidget
 
 from .ui.search_panel import SearchPanel
@@ -16,6 +19,12 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(self.search_panel, "Buscar")
         self.tabs.addTab(self.organizer_panel, "Organizar")
         self.setCentralWidget(self.tabs)
+
+        qss_path = Path(__file__).parent / "ui" / "styles.qss"
+        file = QFile(str(qss_path))
+        if file.open(QFile.ReadOnly):
+            self.setStyleSheet(file.readAll().data().decode())
+            file.close()
 
         self._build_menus()
 

--- a/songsearch/ui/organizer_panel.py
+++ b/songsearch/ui/organizer_panel.py
@@ -21,6 +21,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QStyle,
 )
 
 from ..organizer.plan import plan_moves
@@ -39,7 +40,9 @@ class OrganizerPanel(QWidget):
     def _build_ui(self) -> None:
         main = QVBoxLayout(self)
 
+        style = self.style()
         file_btn = QPushButton("Seleccionar Archivos")
+        file_btn.setIcon(style.standardIcon(QStyle.SP_DialogOpenButton))
         file_btn.clicked.connect(self.select_files)
         main.addWidget(file_btn)
 
@@ -49,6 +52,7 @@ class OrganizerPanel(QWidget):
         self.dest_edit.setReadOnly(True)
         dest_layout.addWidget(self.dest_edit)
         dest_btn = QPushButton("Elegir Destino")
+        dest_btn.setIcon(style.standardIcon(QStyle.SP_DirOpenIcon))
         dest_btn.clicked.connect(self.select_destination)
         dest_layout.addWidget(dest_btn)
         main.addLayout(dest_layout)
@@ -57,6 +61,7 @@ class OrganizerPanel(QWidget):
         main.addWidget(self.files_list)
 
         organize_btn = QPushButton("Organizar")
+        organize_btn.setIcon(style.standardIcon(QStyle.SP_DialogApplyButton))
         organize_btn.clicked.connect(self.organize_files)
         main.addWidget(organize_btn)
 

--- a/songsearch/ui/search_panel.py
+++ b/songsearch/ui/search_panel.py
@@ -32,6 +32,7 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QPushButton,
     QRadioButton,
+    QStyle,
     QSlider,
     QSplitter,
     QTextEdit,
@@ -66,10 +67,15 @@ class SearchPanel(QWidget):
         search_layout.addWidget(self.input_text)
 
         btns = QVBoxLayout()
+        style = self.style()
         self.search_button = QPushButton("Buscar")
+        self.search_button.setIcon(style.standardIcon(QStyle.SP_FileDialogContentsView))
         self.folder_button = QPushButton("Elegir Carpeta")
+        self.folder_button.setIcon(style.standardIcon(QStyle.SP_DirOpenIcon))
         self.update_button = QPushButton("Actualizar Base de Datos")
+        self.update_button.setIcon(style.standardIcon(QStyle.SP_BrowserReload))
         self.clear_button = QPushButton("Limpiar")
+        self.clear_button.setIcon(style.standardIcon(QStyle.SP_DialogResetButton))
         btns.addWidget(self.search_button)
         btns.addWidget(self.folder_button)
         btns.addWidget(self.update_button)
@@ -85,6 +91,7 @@ class SearchPanel(QWidget):
         controls = QHBoxLayout(controls_widget)
         self.play_pause_button = QPushButton("Play")
         self.play_pause_button.setEnabled(False)
+        self.play_pause_button.setIcon(style.standardIcon(QStyle.SP_MediaPlay))
         self.progress_bar = QSlider(Qt.Horizontal)
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setEnabled(False)
@@ -303,9 +310,15 @@ class SearchPanel(QWidget):
         if self.player.state() == QMediaPlayer.PlayingState:
             self.player.pause()
             self.play_pause_button.setText("Play")
+            self.play_pause_button.setIcon(
+                self.style().standardIcon(QStyle.SP_MediaPlay)
+            )
         else:
             self.player.play()
             self.play_pause_button.setText("Pause")
+            self.play_pause_button.setIcon(
+                self.style().standardIcon(QStyle.SP_MediaPause)
+            )
 
     def _update_position(self, pos: int | None = None) -> None:  # pragma: no cover
         # The ``pos`` parameter is part of the Qt signal but the method uses the

--- a/songsearch/ui/styles.qss
+++ b/songsearch/ui/styles.qss
@@ -1,0 +1,20 @@
+QPushButton {
+    padding: 4px 8px;
+    margin: 2px;
+}
+QPushButton:hover {
+    background-color: #e6e6e6;
+}
+QListWidget {
+    border: 1px solid #cccccc;
+    padding: 4px;
+}
+QLineEdit, QTextEdit {
+    padding: 4px;
+    border: 1px solid #cccccc;
+}
+QSlider::handle:horizontal {
+    background-color: #5c5c5c;
+    border-radius: 3px;
+    width: 12px;
+}


### PR DESCRIPTION
## Summary
- add standard QStyle icons to search and organizer panels
- introduce shared stylesheet and apply it in `MainWindow`

## Testing
- `ruff check .`
- `coverage run -m pytest -p pytestqt`
- `python scripts/smoke_app.py` *(fails: QWidget: Must construct a QApplication before a QWidget)*

------
https://chatgpt.com/codex/tasks/task_e_68c742f5e92c832c9321d742cca3f07f