### PR TITLE
Allow editing metadata in organizer

### DIFF
--- a/tests/test_organizer_panel_edit.py
+++ b/tests/test_organizer_panel_edit.py
@@ -1,0 +1,42 @@
+from songsearch.ui.organizer_panel import OrganizerPanel
+
+
+def test_edit_updates_plan_and_destination(monkeypatch, qtbot):
+    def fake_plan_moves(paths, base):
+        return [
+            {
+                "original_path": "song.mp3",
+                "proposed_path": "/dest/OldGenre/2000.mp3",
+                "status": "ok",
+                "reason": "planned",
+                "title": "Title",
+                "artist": "Artist",
+                "album": "",
+                "year": "2000",
+                "month": "",
+                "genre": "OldGenre",
+            }
+        ]
+
+    def fake_build(base, meta, ext):
+        return f"{base}/{meta['genre']}/{meta['year']}{ext}"
+
+    monkeypatch.setattr("songsearch.ui.organizer_panel.plan_moves", fake_plan_moves)
+    monkeypatch.setattr("songsearch.ui.organizer_panel.build_destination", fake_build)
+
+    panel = OrganizerPanel()
+    qtbot.addWidget(panel)
+    panel.file_paths = ["song.mp3"]
+    panel.dest_dir = "/dest"
+    panel.plan_files()
+
+    genre_item = panel.plan_table.item(0, 3)
+    genre_item.setText("NewGenre")
+    assert panel.plan[0]["genre"] == "NewGenre"
+    assert panel.plan[0]["proposed_path"] == "/dest/NewGenre/2000.mp3"
+
+    year_item = panel.plan_table.item(0, 4)
+    year_item.setText("2020")
+    assert panel.plan[0]["year"] == "2020"
+    assert panel.plan[0]["proposed_path"] == "/dest/NewGenre/2020.mp3"
+


### PR DESCRIPTION
## Summary
- show Year and Genre columns in organizer and prefill from move plan
- enable editing of Year and Genre, updating destination on change
- test manual metadata edits adjust plan

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7536bbca4832cbeed3ceb08e18387